### PR TITLE
[Feat] 다른 사람 프로필 조회

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -11,6 +11,7 @@ import styled from "styled-components";
 
 interface ChatList {
   id: number;
+  userSid: string;
   nickname: string;
   profileImgUrl: string;
   recentMessage: string;
@@ -64,6 +65,7 @@ const Chat = () => {
             <ChatPreview
               key={data.id}
               id={data.id}
+              userSid={data.userSid}
               nickname={data.nickname}
               recentMessage={data.recentMessage}
               title={data.title}

--- a/src/app/home/[id]/page.tsx
+++ b/src/app/home/[id]/page.tsx
@@ -24,6 +24,7 @@ interface Price {
 
 interface PostInfo {
   id: number;
+  userSid: string;
   profileUrl: string;
   nickname: string;
   isWriter: boolean;
@@ -137,6 +138,7 @@ const Page = () => {
         <Profile
           nickname={postInfo?.nickname ? postInfo.nickname : ""}
           profileUrl={postInfo?.profileUrl ? postInfo.profileUrl : ""}
+          onClick={() => router.push(`/user/${postInfo?.userSid}`)}
         />
         <Body>
           <Title>{postInfo?.title}</Title>

--- a/src/app/mycloset/page.tsx
+++ b/src/app/mycloset/page.tsx
@@ -276,7 +276,7 @@ const MyCloset = () => {
             </Indicator>
           </IndicatorContainer>
         </SliderContainer>
-        <ListTab />
+        <ListTab listType="me" />
       </Layout>
       {stylePopup && (
         <Modal

--- a/src/app/user/[userSid]/page.tsx
+++ b/src/app/user/[userSid]/page.tsx
@@ -1,0 +1,476 @@
+"use client";
+import AuthAxios from "@/api/authAxios";
+import ListTab from "@/components/common/ListTab";
+import Topbar from "@/components/common/Topbar";
+import ScoreBar from "@/components/myCloset/ScoreBar";
+import { getLevelText } from "@/data/levelData";
+import { useRequireAuth } from "@/hooks/useAuth";
+import { getGenderLabel } from "@/interface/Gender";
+import { theme } from "@/styles/theme";
+import Image from "next/image";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+
+interface ProfileInfo {
+  nickname: string;
+  profileUrl: string;
+  gender: string;
+  level: number;
+  rentalCount: number;
+  height: number;
+  weight: number;
+  shoeSize: number;
+  bodyShapes: string[];
+  categories: string[];
+  styles: string[];
+  followers: number;
+  followees: number;
+}
+
+const MyCloset = () => {
+  useRequireAuth();
+  const router = useRouter();
+  const { userSid } = useParams();
+
+  const [profileInfo, setProfileInfo] = useState<ProfileInfo>();
+
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const sliderRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    AuthAxios.get(`/api/v1/users/profile/${userSid}`)
+      .then((response) => {
+        const data = response.data.result;
+        setProfileInfo(data);
+        console.log(data);
+        console.log(response.data.message);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }, []);
+
+  const goToSlide = (slideIndex: number) => {
+    if (sliderRef.current) {
+      const slideWidth = sliderRef.current.clientWidth;
+      const scrollLeft = slideWidth * slideIndex;
+      sliderRef.current.scrollTo({
+        left: scrollLeft,
+        behavior: "smooth",
+      });
+      setCurrentSlide(slideIndex);
+    }
+  };
+
+  return (
+    <>
+      <Layout>
+        <Background />
+        {profileInfo && (
+          <>
+            <Image
+              src="/assets/images/logo_black.svg"
+              width={101}
+              height={18}
+              alt="logo"
+              onClick={() => router.push("/home")}
+              style={{ cursor: "pointer" }}
+            />
+            <TopRow>
+              <Topbar
+                text={`${profileInfo.nickname} 님의 옷장`}
+                icon={true}
+                align="left"
+              />
+            </TopRow>
+            <Profile>
+              <ProfileImage>
+                <Image
+                  src={
+                    profileInfo.profileUrl || "/assets/images/basic_profile.svg"
+                  }
+                  layout="fill"
+                  objectFit="cover"
+                  alt="profile"
+                />
+              </ProfileImage>
+              <Text>
+                <Top>
+                  <Nickname>
+                    {profileInfo?.nickname}
+                    <Gender>{getGenderLabel(profileInfo.gender)}</Gender>
+                  </Nickname>
+                </Top>
+                <Level>
+                  {profileInfo?.level &&
+                    `${getLevelText(profileInfo.level) + ""} (Lv. ${
+                      profileInfo?.level
+                    })`}
+                  <LevelText>
+                    {profileInfo?.rentalCount}개의 옷을 아꼈어요!
+                  </LevelText>
+                </Level>
+              </Text>
+            </Profile>
+          </>
+        )}
+        <SliderContainer>
+          <Slider ref={sliderRef}>
+            <Slide>
+              <ScoreBox>
+                <InfoTop>
+                  <Title>옷장점수</Title>
+                  <Comment>당신은 멀끔한 옷장을 가졌군요!</Comment>
+                  <Score>10점</Score>
+                </InfoTop>
+                <ScoreBar recentScore={10} nickname={profileInfo?.nickname} />
+                <MoreReview>거래 후기 확인하기</MoreReview>
+              </ScoreBox>
+            </Slide>
+            <Slide>
+              <StyleBox>
+                <StyleBoxDiv>
+                  <div>
+                    <Title>스펙</Title>
+                    <SpecText>
+                      <div>키</div>
+                      <div>
+                        {profileInfo?.height
+                          ? `${profileInfo.height}cm`
+                          : "미공개"}
+                      </div>
+                      <div>몸무게</div>
+                      <div>
+                        {profileInfo?.weight
+                          ? `${profileInfo.weight}kg`
+                          : "미공개"}
+                      </div>
+                      <div>발 크기</div>
+                      <div>
+                        {profileInfo?.shoeSize
+                          ? `${profileInfo.shoeSize}mm`
+                          : "미공개"}
+                      </div>
+                    </SpecText>
+                  </div>
+                  <Keywords>
+                    {profileInfo?.bodyShapes[0] ? (
+                      <>
+                        {profileInfo?.bodyShapes.map((data, index) => (
+                          <Keyword key={index} type={1}>
+                            {data}
+                          </Keyword>
+                        ))}
+                      </>
+                    ) : (
+                      <Keyword type={0}>체형정보 미기입</Keyword>
+                    )}
+                  </Keywords>
+                </StyleBoxDiv>
+                <StyleBoxDiv>
+                  <div>
+                    <Title>취향</Title>
+                    <StyleText>
+                      {profileInfo?.categories.map((data, index) => (
+                        <span key={index}>
+                          {data}
+                          {`  `}
+                        </span>
+                      ))}
+                    </StyleText>
+                  </div>
+                  <Keywords>
+                    {profileInfo?.styles[0] ? (
+                      <>
+                        {profileInfo?.styles.map((data, index) => (
+                          <Keyword key={index} type={2}>
+                            {data}
+                          </Keyword>
+                        ))}
+                      </>
+                    ) : (
+                      <Keyword type={0}>스타일 미기입</Keyword>
+                    )}
+                  </Keywords>
+                </StyleBoxDiv>
+              </StyleBox>
+            </Slide>
+          </Slider>
+          <IndicatorContainer>
+            <Indicator onClick={() => goToSlide(0)} active={currentSlide === 0}>
+              {/* 스코어 박스 */}
+            </Indicator>
+            <Indicator onClick={() => goToSlide(1)} active={currentSlide === 1}>
+              {/* 스타일 박스 */}
+            </Indicator>
+          </IndicatorContainer>
+        </SliderContainer>
+        <ListTab listType="other" userSid={String(userSid)} />
+      </Layout>
+    </>
+  );
+};
+
+export default MyCloset;
+
+const Layout = styled.div`
+  width: 100%;
+  height: 100vh;
+  overflow-y: scroll;
+  padding: 42px 20px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: none;
+  background: ${theme.colors.ivory};
+  z-index: 1;
+`;
+
+const Background = styled.div`
+  width: 100%;
+  max-width: 480px;
+  height: 500px;
+  border-radius: 0 0 200px 200px;
+  background: linear-gradient(180deg, #d8d1ff 0%, #f3f1ff 100%);
+  position: fixed;
+  top: 0px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: -10;
+  overflow: hidden;
+`;
+
+const TopRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+/* 프로필 */
+const Profile = styled.div`
+  width: 100%;
+  height: 120px;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+
+const ProfileImage = styled.div`
+  position: relative;
+  width: 70px;
+  height: 70px;
+  background: white;
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const Text = styled.div`
+  width: calc(100% - 70px);
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+  margin-left: 30px;
+`;
+
+const Top = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Nickname = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  ${(props) => props.theme.fonts.h2_bold};
+`;
+
+const Gender = styled.span`
+  color: ${theme.colors.purple500};
+  ${(props) => props.theme.fonts.c3_medium};
+  margin-top: 5px;
+`;
+
+const ProfileButton = styled.button`
+  width: 74px;
+  height: 30px;
+  border: none;
+  border-radius: 5px;
+  background: ${theme.colors.purple50};
+  color: ${theme.colors.b200};
+  ${(props) => props.theme.fonts.c2_medium};
+  white-space: nowrap;
+  cursor: pointer;
+`;
+
+const Level = styled.div`
+  height: 21px;
+  display: flex;
+  flex-direction: column;
+  color: ${theme.colors.b500};
+  ${(props) => props.theme.fonts.b3_medium};
+`;
+
+const LevelText = styled.div`
+  color: ${theme.colors.b200};
+  ${(props) => props.theme.fonts.c3_medium};
+`;
+
+/* 옷장점수 & 스펙, 취향 */
+const SliderContainer = styled.div`
+  width: 100%;
+  position: relative;
+  margin-bottom: 35px;
+`;
+
+const Slider = styled.div`
+  width: 100%;
+  display: flex;
+  overflow: hidden;
+  scroll-behavior: smooth;
+`;
+
+const Slide = styled.div`
+  width: 100%;
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ScoreBox = styled.div`
+  width: 100%;
+  height: 150px;
+  padding: 20px;
+  border-radius: 20px;
+  background: ${theme.colors.white};
+  box-shadow: 0px 4px 20px 0px rgba(215, 215, 215, 0.25);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+`;
+
+const InfoTop = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 28px;
+`;
+
+const Title = styled.div`
+  ${(props) => props.theme.fonts.b3_bold};
+`;
+
+const Comment = styled.div`
+  color: ${theme.colors.purple300};
+  ${(props) => props.theme.fonts.c3_medium};
+`;
+
+const Score = styled.div`
+  color: ${theme.colors.purple500};
+  ${(props) => props.theme.fonts.c3_bold};
+`;
+
+const MoreReview = styled.button`
+  color: ${theme.colors.b100};
+  ${(props) => props.theme.fonts.b3_medium};
+  text-decoration-line: underline;
+  margin-top: auto;
+  border: none;
+  background: none;
+`;
+
+const StyleBox = styled(ScoreBox)`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: flex-start;
+  position: relative;
+`;
+
+const Edit = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: ${theme.colors.b100};
+  ${(props) => props.theme.fonts.c2_medium};
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+`;
+
+const StyleBoxDiv = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const SpecText = styled(LevelText)`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  margin-top: 10px;
+  row-gap: 3px;
+`;
+
+const StyleText = styled(LevelText)`
+  margin-top: 10px;
+  row-gap: 3px;
+`;
+
+const Keywords = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 5px;
+`;
+
+const Keyword = styled.div<{ type: number }>`
+  color: ${({ type, theme }) => {
+    if (type === 1) return "#e071d5";
+    if (type === 2) return theme.colors.purple500;
+    return theme.colors.gray800;
+  }};
+  ${(props) => props.theme.fonts.c3_semiBold};
+  padding: 3px 6px;
+  border: 1px solid
+    ${({ type, theme }) => {
+      if (type === 1) return "#e071d5";
+      if (type === 2) return theme.colors.purple500;
+      return theme.colors.gray800;
+    }};
+  border-radius: 10px;
+  background: ${({ type, theme }) => {
+    if (type === 1) return "#f8e4ff";
+    if (type === 2) return theme.colors.purple150;
+    return theme.colors.gray100;
+  }};
+`;
+
+/* 인디케이터 */
+const IndicatorContainer = styled.div`
+  width: 100%;
+  display: flex;
+  margin-top: 10px;
+`;
+
+const Indicator = styled.div<{ active: boolean }>`
+  width: 50%;
+  height: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${({ active }) =>
+    active ? theme.colors.gray900 : theme.colors.gray400};
+  border-radius: 3px;
+  cursor: pointer;
+  ${(props) => props.theme.fonts.b3_medium};
+`;

--- a/src/components/chat/ChatPreview.tsx
+++ b/src/components/chat/ChatPreview.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 interface ChatPreviewProps {
   id: number;
+  userSid: string;
   nickname: string;
   recentMessage: string;
   title: string;
@@ -16,6 +17,7 @@ interface ChatPreviewProps {
 
 const ChatPreview: React.FC<ChatPreviewProps> = ({
   id,
+  userSid,
   nickname,
   recentMessage,
   title,
@@ -25,30 +27,30 @@ const ChatPreview: React.FC<ChatPreviewProps> = ({
   recentMessageTime,
 }) => {
   const router = useRouter();
+
   const handleChatDetail = () => {
     router.push(`/chat/${id}`);
+  };
+
+  const handleUserClick = (
+    e: React.MouseEvent<HTMLDivElement | HTMLImageElement>,
+    route: string
+  ) => {
+    e.stopPropagation(); // 부모 요소로의 클릭 전파 방지
+    router.push(route);
   };
 
   return (
     <Container onClick={handleChatDetail}>
       <Left>
-        {profileImgUrl ? (
-          <ProfileImage
-            src={profileImgUrl}
-            width={56}
-            height={56}
-            alt="profile"
-            style={{ borderRadius: "100px", background: "white" }}
-          />
-        ) : (
-          <ProfileImage
-            src={"/assets/images/profile.svg"}
-            width={56}
-            height={56}
-            alt="profile"
-            style={{ borderRadius: "100px" }}
-          />
-        )}
+        <ProfileImage
+          src={profileImgUrl || `/assets/images/basic_profile.svg`}
+          width={56}
+          height={56}
+          alt="profile"
+          style={{ borderRadius: "100px", background: "white" }}
+          onClick={(e) => handleUserClick(e, `/user/${userSid}`)}
+        />
         {rentalImgUrl ? (
           <ProductImage
             src={rentalImgUrl}
@@ -70,7 +72,9 @@ const ChatPreview: React.FC<ChatPreviewProps> = ({
       <Right>
         <Top>
           <Name>
-            <NickName>{nickname}</NickName>
+            <NickName onClick={(e) => handleUserClick(e, `/user/${userSid}`)}>
+              {nickname}
+            </NickName>
             {rentalState === "RENTED" && (
               <StateBox check={true}>대여중</StateBox>
             )}
@@ -106,6 +110,7 @@ const Container = styled.div`
   display: flex;
   justify-content: flex-start;
   gap: 20px;
+  z-index: 0;
 `;
 
 const Left = styled.div`
@@ -119,6 +124,7 @@ const ProfileImage = styled(Image)`
   top: 10px;
   left: 0;
   z-index: 100;
+  cursor: pointer;
 `;
 
 const ProductImage = styled(Image)`
@@ -159,6 +165,7 @@ const Chat = styled.div`
 
 const NickName = styled.div`
   ${(props) => props.theme.fonts.b2_medium};
+  cursor: pointer;
 `;
 const Preview = styled.div`
   ${(props) => props.theme.fonts.b3_regular};

--- a/src/components/common/ListTab.tsx
+++ b/src/components/common/ListTab.tsx
@@ -8,14 +8,37 @@ import MyClosetContent from "../myCloset/MyClosetContent";
 import MyShareContent from "../myCloset/MyShareContent";
 import TransShareContent from "../myCloset/TransShareContent";
 import TransRentContent from "../myCloset/TransRentContent";
+import { useParams } from "next/navigation";
+import { useRouter } from "next/router";
 
-const ListTab = () => {
+type listType = "me" | "other";
+
+interface ListTabProps {
+  listType: listType;
+  userSid?: string;
+}
+
+// 각 탭의 데이터 타입 정의
+interface TabItem {
+  tab: string;
+  key: string;
+  sub?: {
+    subTab: string;
+    key: string;
+  }[];
+}
+
+const ListTab: React.FC<ListTabProps> = ({ listType, userSid }) => {
   // const router = useRouter();
   const { currentTab, setCurrentTab, currentSubTab, setCurrentSubTab } =
     useCurrentTab();
 
   const [selectedTab, setSelectedTab] = useState<number>(0);
   const [selectedSubTab, setSelectedSubTab] = useState<number>(0);
+
+  // 탭 정보
+  const tabsToDisplay: TabItem[] =
+    listType === "other" ? [myClosetTabs[0]] : myClosetTabs;
 
   const handleTabClick = (tabIndex: number) => {
     setSelectedTab(tabIndex);
@@ -36,7 +59,7 @@ const ListTab = () => {
   return (
     <Container>
       <ListContainer>
-        {myClosetTabs.map((item, index) => (
+        {tabsToDisplay.map((item, index) => (
           <Tab
             key={index}
             selected={selectedTab === index}
@@ -62,7 +85,11 @@ const ListTab = () => {
           </Tab>
         ))}
       </ListContainer>
-      <ContentArea currentTab={currentTab} currentSubTab={currentSubTab} />
+      <ContentArea
+        currentTab={currentTab}
+        currentSubTab={currentSubTab}
+        userSid={userSid}
+      />
     </Container>
   );
 };
@@ -70,14 +97,16 @@ const ListTab = () => {
 function ContentArea({
   currentTab,
   currentSubTab,
+  userSid,
 }: {
   currentTab: string;
   currentSubTab: string;
+  userSid?: string;
 }) {
   if (currentTab === "my" && currentSubTab === "closet") {
-    return <MyClosetContent />;
+    return <MyClosetContent userSid={userSid || ""} />;
   } else if (currentTab === "my" && currentSubTab === "share") {
-    return <MyShareContent />;
+    return <MyShareContent userSid={userSid || ""} />;
   } else if (currentTab === "transaction" && currentSubTab === "sharing") {
     return <TransShareContent />;
   } else if (currentTab === "transaction" && currentSubTab === "rental") {
@@ -98,12 +127,13 @@ const Container = styled.div`
 
 const ListContainer = styled.div`
   width: 100%;
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  place-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 0px 40px;
   border-bottom: 1px solid ${theme.colors.gray200};
   margin-bottom: 30px;
+  gap: 20px;
 `;
 
 const Tab = styled.div<{ selected: boolean }>`

--- a/src/components/common/Topbar.tsx
+++ b/src/components/common/Topbar.tsx
@@ -9,11 +9,18 @@ export interface TopbarProps {
   text: string;
   icon?: boolean;
   link?: string;
+  fontSize?: keyof typeof theme.fonts;
   align: "left" | "center";
 }
 
 const Topbar = (props: TopbarProps) => {
-  const { text, icon = false, link, align = "left" } = props;
+  const {
+    text,
+    icon = false,
+    link,
+    fontSize = "h2_bold",
+    align = "left",
+  } = props;
   const router = useRouter();
 
   const handleBackButtonClick = () => {
@@ -35,7 +42,9 @@ const Topbar = (props: TopbarProps) => {
           onClick={handleBackButtonClick}
         />
       )}
-      <Text $align={align}>{text}</Text>
+      <Text $align={align} $fontSize={fontSize}>
+        {text}
+      </Text>
     </Container>
   );
 };
@@ -51,11 +60,14 @@ const Container = styled.div`
   img {
     cursor: pointer;
   }
-  ${({ theme }) => theme.fonts.h2_bold};
   color: ${({ theme }) => theme.colors.b500};
 `;
 
-const Text = styled.div<{ $align: string }>`
+const Text = styled.div<{
+  $align: string;
+  $fontSize: keyof typeof theme.fonts;
+}>`
   width: 100%;
   text-align: ${(props) => props.$align};
+  ${({ $fontSize, theme }) => theme.fonts[$fontSize]};
 `;

--- a/src/components/home/Profile.tsx
+++ b/src/components/home/Profile.tsx
@@ -4,11 +4,12 @@ import styled from "styled-components";
 interface Profile {
   nickname: string;
   profileUrl: string;
+  onClick: () => void;
 }
 
-const Profile: React.FC<Profile> = ({ nickname, profileUrl }) => {
+const Profile: React.FC<Profile> = ({ nickname, profileUrl, onClick }) => {
   return (
-    <Div>
+    <Div onClick={onClick}>
       {profileUrl ? (
         <Image
           src={profileUrl}
@@ -33,7 +34,7 @@ const Profile: React.FC<Profile> = ({ nickname, profileUrl }) => {
 
 export default Profile;
 
-const Div = styled.div`
+const Div = styled.button`
   width: 100%;
   height: 73px;
   padding: 14px 48px;
@@ -44,4 +45,6 @@ const Div = styled.div`
   align-items: center;
   gap: 29px;
   ${(props) => props.theme.fonts.b2_regular};
+  border: none;
+  cursor: pointer;
 `;

--- a/src/components/myCloset/MyClosetContent.tsx
+++ b/src/components/myCloset/MyClosetContent.tsx
@@ -1,9 +1,45 @@
 import styled from "styled-components";
 import SquarePost from "../common/SquarePost";
+import { useEffect, useState } from "react";
+import AuthAxios from "@/api/authAxios";
+import { PostList } from "@/data/homeData";
 
-const MyClosetContent = () => {
+interface MyClosetContentProps {
+  userSid?: string;
+}
+
+const MyClosetContent: React.FC<MyClosetContentProps> = ({ userSid }) => {
+  // const [postList, setPostList] = useState<PostList[]>();
+
+  // /* 보유 > 옷장 등록 목록 조회 */
+  // useEffect(() => {
+  //   const url = userSid
+  //     ? `/api/v1/closet/${userSid}/rentals`
+  //     : `/api/v1/closet/rentals`;
+  //   AuthAxios.get(url)
+  //     .then((response) => {
+  //       const data = response.data.result;
+  //       setPostList(data);
+  //       console.log(data);
+  //       console.log(response.data.message);
+  //     })
+  //     .catch((error) => {
+  //       console.log(error);
+  //     });
+  // }, []);
+
   return (
     <GridContainer>
+      {/* {postList?.map((data) => (
+        <SquarePost
+          key={data.id}
+          id={data.id}
+          imgUrl={data.imgUrl}
+          title={data.title}
+          minPrice={data.minPrice}
+          createdAt={data.createdAt}
+        />
+      ))} */}
       <SquarePost />
       <SquarePost />
       <SquarePost />

--- a/src/components/myCloset/MyShareContent.tsx
+++ b/src/components/myCloset/MyShareContent.tsx
@@ -1,15 +1,22 @@
-import styled from "styled-components";
-import Post from "../home/Post";
 import { PostList } from "@/data/homeData";
 import { useEffect, useState } from "react";
 import AuthAxios from "@/api/authAxios";
+import Post from "../home/Post";
+import styled from "styled-components";
 
-const MyShareContent = () => {
+interface MyShareContentProps {
+  userSid?: string;
+}
+
+const MyShareContent: React.FC<MyShareContentProps> = ({ userSid }) => {
   const [postList, setPostList] = useState<PostList[]>();
 
   /* 보유 > 공유 등록 목록 조회 */
   useEffect(() => {
-    AuthAxios.get("/api/v1/closet/rentals")
+    const url = userSid
+      ? `/api/v1/closet/${userSid}/rentals`
+      : `/api/v1/closet/rentals`;
+    AuthAxios.get(url)
       .then((response) => {
         const data = response.data.result;
         setPostList(data);

--- a/src/components/myCloset/ScoreBar.tsx
+++ b/src/components/myCloset/ScoreBar.tsx
@@ -4,10 +4,11 @@ import styled from "styled-components";
 
 interface ScoreBarProps {
   recentScore: number;
+  nickname?: string;
 }
 
 const ScoreBar: React.FC<ScoreBarProps> = (props) => {
-  const { recentScore } = props;
+  const { recentScore, nickname } = props;
 
   return (
     <Bar>
@@ -19,7 +20,7 @@ const ScoreBar: React.FC<ScoreBarProps> = (props) => {
           </Column>
         ))}
       </Dots>
-      <Location recentScore={recentScore}>나의 옷장</Location>
+      <Location recentScore={recentScore}>{nickname || "나"}의 옷장</Location>
     </Bar>
   );
 };
@@ -74,8 +75,8 @@ const Score = styled.div`
 `;
 
 const Location = styled.div<{ recentScore: number }>`
-  width: 56px;
   height: 20px;
+  padding: 4px 8px;
   border-radius: 10px;
   background: ${theme.colors.purple100};
   display: inline-flex;


### PR DESCRIPTION
## 연관 이슈
close #38

<br/>

## 🔍 작업 내용
- 다른 사람 프로필 조회 UI
- 다른 사람 프로필 조회 API 연동 (공유옷장/채팅목록 통한 경로)
- ListTab 구조 수정
 
<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/04112087-53cf-48c5-b2ae-9c862c8fa911


<br/>

## 📁 메모
- 채팅창 내의 프로필 경로는 프로필 이미지 추가 후에 연결하기
- 채팅창 내에서 프로필 볼 때도 페이지 이동하는게 좋을지 고민해보기
(모달이 나을 수도 있을 것 같음)

<br/>
