### PR TITLE
[Feat] 거래 후기 내역 조회

### DIFF
--- a/src/app/mycloset/page.tsx
+++ b/src/app/mycloset/page.tsx
@@ -182,7 +182,9 @@ const MyCloset = () => {
                   <Score>10점</Score>
                 </InfoTop>
                 <ScoreBar recentScore={10} />
-                <MoreReview>거래 후기 확인하기</MoreReview>
+                <MoreReview onClick={() => router.push("/mycloset/review")}>
+                  거래 후기 확인하기
+                </MoreReview>
               </ScoreBox>
             </Slide>
             <Slide>

--- a/src/app/mycloset/review/page.tsx
+++ b/src/app/mycloset/review/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import AuthAxios from "@/api/authAxios";
+import ReviewPage, { ReviewProps } from "@/components/review/ReviewPage";
+import { theme } from "@/styles/theme";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const MyClosetReview = () => {
+  const router = useRouter();
+  const [review, setReview] = useState<ReviewProps>();
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await AuthAxios.get("/api/v1/reviews");
+        const data = response.data.result;
+        console.log(data);
+        setReview(data);
+        console.log(response.data.message);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  return (
+    <>
+      <Layout>
+        <Background />
+        <Image
+          src="/assets/images/logo_black.svg"
+          width={101}
+          height={18}
+          alt="logo"
+          onClick={() => router.push("/home")}
+          style={{ cursor: "pointer" }}
+        />
+        <Top>
+          <Image
+            src="/assets/icons/ic_arrow.svg"
+            width={24}
+            height={24}
+            alt="back"
+            onClick={() => router.back()}
+            style={{ cursor: "pointer" }}
+          />
+          거래 후기
+          <div />
+        </Top>
+        <Content>
+          {review && (
+            <ReviewPage
+              keywordReviews={review.keywordReviews}
+              textReviews={review.textReviews}
+            />
+          )}
+        </Content>
+      </Layout>
+    </>
+  );
+};
+
+export default MyClosetReview;
+
+const Layout = styled.div`
+  width: 100%;
+  height: 100vh;
+  overflow-y: scroll;
+  padding: 42px 20px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: none;
+  background: ${theme.colors.ivory};
+  z-index: 1;
+`;
+const Background = styled.div`
+  width: 100%;
+  max-width: 480px;
+  height: 500px;
+  border-radius: 0 0 200px 200px;
+  background: linear-gradient(180deg, #d8d1ff 0%, #f3f1ff 100%);
+  position: fixed;
+  top: 0px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: -10;
+  overflow: hidden;
+`;
+
+const Top = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 22px;
+  margin-bottom: 15px;
+  ${(props) => props.theme.fonts.h2_bold};
+`;
+
+const Content = styled.div`
+  display: flex;
+  padding: 35px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+`;

--- a/src/app/user/[userSid]/page.tsx
+++ b/src/app/user/[userSid]/page.tsx
@@ -125,7 +125,11 @@ const MyCloset = () => {
                   <Score>10점</Score>
                 </InfoTop>
                 <ScoreBar recentScore={10} nickname={profileInfo?.nickname} />
-                <MoreReview>거래 후기 확인하기</MoreReview>
+                <MoreReview
+                  onClick={() => router.push(`/user/${userSid}/review`)}
+                >
+                  거래 후기 확인하기
+                </MoreReview>
               </ScoreBox>
             </Slide>
             <Slide>
@@ -268,7 +272,7 @@ const ProfileImage = styled.div`
 `;
 
 const Text = styled.div`
-  width: calc(100% - 70px);
+  width: calc(100% - 105px);
   display: flex;
   flex-direction: column;
   gap: 13px;

--- a/src/app/user/[userSid]/review/page.tsx
+++ b/src/app/user/[userSid]/review/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import AuthAxios from "@/api/authAxios";
+import ReviewPage, { ReviewProps } from "@/components/review/ReviewPage";
+import { theme } from "@/styles/theme";
+import Image from "next/image";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const UserReview = () => {
+  const router = useRouter();
+  const { userSid } = useParams();
+  const [review, setReview] = useState<ReviewProps>();
+
+  useEffect(() => {
+    const fetchUserReview = async () => {
+      try {
+        const response = await AuthAxios.get(`/api/v1/reviews/${userSid}`);
+        const data = response.data.result;
+        console.log(data);
+        setReview(data);
+        console.log(response.data.message);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchUserReview();
+  }, []);
+
+  return (
+    <>
+      <Layout>
+        <Background />
+        <Image
+          src="/assets/images/logo_black.svg"
+          width={101}
+          height={18}
+          alt="logo"
+          onClick={() => router.push("/home")}
+          style={{ cursor: "pointer" }}
+        />
+        <Top>
+          <Image
+            src="/assets/icons/ic_arrow.svg"
+            width={24}
+            height={24}
+            alt="back"
+            onClick={() => router.back()}
+            style={{ cursor: "pointer" }}
+          />
+          거래 후기
+          <div />
+        </Top>
+        <Content>
+          {review && (
+            <ReviewPage
+              keywordReviews={review.keywordReviews}
+              textReviews={review.textReviews}
+            />
+          )}
+        </Content>
+      </Layout>
+    </>
+  );
+};
+
+export default UserReview;
+
+const Layout = styled.div`
+  width: 100%;
+  height: 100vh;
+  overflow-y: scroll;
+  padding: 42px 20px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: none;
+  background: ${theme.colors.ivory};
+  z-index: 1;
+`;
+const Background = styled.div`
+  width: 100%;
+  max-width: 480px;
+  height: 500px;
+  border-radius: 0 0 200px 200px;
+  background: linear-gradient(180deg, #d8d1ff 0%, #f3f1ff 100%);
+  position: fixed;
+  top: 0px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: -10;
+  overflow: hidden;
+`;
+
+const Top = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 22px;
+  margin-bottom: 15px;
+  ${(props) => props.theme.fonts.h2_bold};
+`;
+
+const Content = styled.div`
+  display: flex;
+  padding: 35px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+`;

--- a/src/components/review/KeywordBox.tsx
+++ b/src/components/review/KeywordBox.tsx
@@ -1,0 +1,31 @@
+import { theme } from "@/styles/theme";
+import React from "react";
+import styled from "styled-components";
+import { KeywordProps } from "./ReviewPage";
+
+const KeywordBox: React.FC<KeywordProps> = ({ keyword, count }) => {
+  return (
+    <Box>
+      {keyword}
+      <Count>{count}</Count>
+    </Box>
+  );
+};
+
+export default KeywordBox;
+
+const Box = styled.div`
+  height: 29px;
+  padding: 5px 14px;
+  border-radius: 15px;
+  background: ${theme.colors.gray100};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
+  ${(props) => props.theme.fonts.b2_regular};
+`;
+
+const Count = styled.div`
+  color: ${theme.colors.purple500};
+`;

--- a/src/components/review/ReviewPage.tsx
+++ b/src/components/review/ReviewPage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import KeywordBox from "./KeywordBox";
+import TextBox from "./TextBox";
+import styled from "styled-components";
+import { theme } from "@/styles/theme";
+import Image from "next/image";
+
+export interface KeywordProps {
+  keyword: string;
+  count: number;
+}
+
+export interface TextProps {
+  nickname: string;
+  profileUrl: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface ReviewProps {
+  keywordReviews: KeywordProps[];
+  textReviews: TextProps[];
+}
+
+const ReviewPage: React.FC<ReviewProps> = ({ keywordReviews, textReviews }) => {
+  return (
+    <Container>
+      <Image
+        src={"/assets/images/basic_profile.svg"}
+        width={147}
+        height={147}
+        alt="profile"
+        style={{ borderRadius: "50%" }}
+      />
+      <div>
+        <Label>받은 키워드 후기</Label>
+        <Keywords>
+          {keywordReviews.map((item, index) => (
+            <KeywordBox key={index} keyword={item.keyword} count={item.count} />
+          ))}
+        </Keywords>
+      </div>
+      <div>
+        <Label>받은 텍스트 후기</Label>
+        <Texts>
+          {textReviews.map((item, index) => (
+            <TextBox
+              key={index}
+              nickname={item.nickname}
+              profileUrl={item.profileUrl}
+              content={item.content}
+              createdAt={item.createdAt}
+            />
+          ))}
+        </Texts>
+      </div>
+    </Container>
+  );
+};
+
+export default ReviewPage;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 50px;
+`;
+
+const Label = styled.div`
+  color: ${theme.colors.b500};
+  ${(props) => props.theme.fonts.b2_bold};
+  margin-bottom: 18px;
+`;
+
+const Keywords = styled.div`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`;
+
+const Texts = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;

--- a/src/components/review/TextBox.tsx
+++ b/src/components/review/TextBox.tsx
@@ -1,0 +1,76 @@
+import { theme } from "@/styles/theme";
+import Image from "next/image";
+import React from "react";
+import styled from "styled-components";
+import { TextProps } from "./ReviewPage";
+
+const TextBox: React.FC<TextProps> = ({
+  nickname,
+  profileUrl,
+  content,
+  createdAt,
+}) => {
+  return (
+    <Box>
+      <Image
+        src={profileUrl}
+        width={45}
+        height={45}
+        alt="user"
+        style={{ borderRadius: "50%" }}
+      />
+      <Right>
+        <Top>
+          <Nickname>{nickname}</Nickname>
+          <Time>{createdAt}</Time>
+        </Top>
+        <Content>{content}</Content>
+      </Right>
+    </Box>
+  );
+};
+
+export default TextBox;
+
+const Box = styled.div`
+  width: 100%;
+  padding: 15px 25px 15px 15px;
+  border-radius: 10px;
+  background: ${theme.colors.white};
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 18px;
+`;
+
+const Right = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 5px;
+`;
+
+const Top = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: ${theme.colors.purple500};
+`;
+
+const Nickname = styled.div`
+  color: ${theme.colors.b500};
+  ${(props) => props.theme.fonts.b2_bold};
+`;
+
+const Time = styled.div`
+  color: ${theme.colors.gray950};
+  ${(props) => props.theme.fonts.c1_regular};
+`;
+
+const Content = styled.div`
+  color: #383838;
+  ${(props) => props.theme.fonts.b2_regular};
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -31,6 +31,7 @@ const colors = {
   gray700: "#C0C0C0",
   gray800: "#A9A9A9",
   gray900: "#8F8F8F",
+  gray950: "#626262",
   
   linear_purple: "linear-gradient(180deg, #796EF2 0%, #8677E1 100%)",
   linear_btn:"",


### PR DESCRIPTION
## 연관 이슈
close #53

<br/>

## 🔍 작업 내용
거래 후기 내역 조회

- 거래 후기 내역 조회 UI
- 나의 거래 내역 후기 조회 API 연동
- 남의 거래 내역 후기 조회 API 연동

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/26a776bd-e2be-4f52-bad8-9ee573ae3ef8



<br/>

## 📁 메모
- 프로필 이미지는 API 응답값으로 받은 뒤, 연동 예정
<br/>

<br/>
