### PR TITLE
[Feat] 보유글을 선택해 대여글 작성

### DIFF
--- a/src/app/home/[id]/modify/page.tsx
+++ b/src/app/home/[id]/modify/page.tsx
@@ -44,6 +44,7 @@ const Modify = () => {
     (state: RootState) => state.category.selectedStyle
   );
 
+  const [clothesId, setClothesId] = useState<number | null>(null);
   const [images, setImages] = useState<File[]>([]);
   const [inputs, setInputs] = useState<{
     title: string;
@@ -92,6 +93,9 @@ const Modify = () => {
       .then(async (response) => {
         const data = response.data.result;
         setInputs(data);
+        if (data.clothesId) {
+          setClothesId(data.clothesId);
+        }
         dispatch(setSelectedGender(data.gender));
         dispatch(setSelectedCategory(data.category));
         dispatch(setSelectedStyle(data.style));
@@ -141,6 +145,7 @@ const Modify = () => {
             brand: inputs.brand,
             size: inputs.size,
             fit: inputs.fit,
+            clothesId: clothesId || null,
           }),
         ],
         { type: "application/json" }

--- a/src/app/home/[id]/page.tsx
+++ b/src/app/home/[id]/page.tsx
@@ -26,6 +26,7 @@ interface Price {
 
 interface PostInfo {
   id: number;
+  clothesId: number;
   userSid: string;
   profileUrl: string;
   nickname: string;

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -118,7 +118,7 @@ const Home = () => {
             </Posts>
           </Content>
         </Layout>
-        <Edit onClick={() => router.push("/home/write")}>
+        <Edit onClick={() => router.push("/home/write/choice")}>
           <Image
             src="/assets/icons/ic_edit.svg"
             width={48}

--- a/src/app/home/write/choice/page.tsx
+++ b/src/app/home/write/choice/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import Button from "@/components/common/Button";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import Post from "@/components/home/Post";
+import AuthAxios from "@/api/authAxios";
+import { postList, PostList } from "@/data/homeData";
+import { theme } from "@/styles/theme";
+
+const WriteChoice = () => {
+  const router = useRouter();
+
+  // 추후 보유글 목록 조회 API 연동 후 수정
+  // const [postList, setPostList] = useState<PostList[]>();
+
+  // 예시 데이터 - 추후 삭제
+  const [exPostList, setExPostList] = useState<PostList[] | undefined>(
+    postList
+  );
+
+  const [clothesId, setClothesId] = useState<number | undefined>();
+
+  /* 보유글 목록 조회 */
+  // useEffect(() => {
+  //   AuthAxios.get("/api/v1/clothes")
+  //     .then((response) => {
+  //       const data = response.data.result;
+  //       setPostList(data);
+  //       console.log(data);
+  //       console.log(response.data.message);
+  //     })
+  //     .catch((error) => {
+  //       console.log(error);
+  //     });
+  // }, []);
+
+  const handleClickChoice = (id: number) => {
+    if (clothesId === id) {
+      setClothesId(undefined);
+    } else {
+      setClothesId(id);
+    }
+  };
+
+  const handleChoicePost = () => {
+    router.push(`/home/write/post?clothesId=${clothesId}`);
+  };
+
+  return (
+    <Layout>
+      <div>
+        <Image
+          src="/assets/images/logo_black.svg"
+          width={101}
+          height={18}
+          alt="logo"
+          onClick={() => router.push("/home")}
+          style={{ cursor: "pointer" }}
+        />
+        <Top>
+          <Image
+            src="/assets/icons/ic_arrow.svg"
+            width={24}
+            height={24}
+            alt="back"
+            onClick={() => router.back()}
+            style={{ cursor: "pointer" }}
+          />
+          대여 글 작성
+        </Top>
+        <Sub>보유 목록 중 대여 글 작성할 옷을 선택해주세요.</Sub>
+        <Content>
+          <Posts>
+            {exPostList?.map((data, index) => (
+              <PostContainer key={data.id}>
+                <Post
+                  key={data.id}
+                  id={data.id}
+                  imgUrl={data.imgUrl}
+                  title={data.title}
+                  minPrice={data.minPrice}
+                  createdAt={data.createdAt}
+                  nickname={data.nickname}
+                  onClickChoice={handleClickChoice}
+                  isSelected={clothesId === data.id}
+                />
+                {index < exPostList.length - 1 && <Divider />}
+              </PostContainer>
+            ))}
+          </Posts>
+        </Content>
+      </div>
+      <SubmitButton>
+        <Button
+          buttonType="primary"
+          size="large"
+          text="선택 완료"
+          onClick={handleChoicePost}
+          disabled={!clothesId}
+        />
+      </SubmitButton>
+    </Layout>
+  );
+};
+
+export default WriteChoice;
+
+const Layout = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow-y: scroll;
+  padding: 37px 30px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+`;
+
+const Top = styled.div`
+  width: calc(50% + 60px);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 18px;
+  margin-bottom: 15px;
+  ${(props) => props.theme.fonts.h2_bold};
+`;
+
+const Sub = styled.div`
+  width: 100%;
+  text-align: center;
+  margin: 27px 0;
+  color: ${theme.colors.b500};
+  ${(props) => props.theme.fonts.b2_semiBold};
+`;
+
+const Content = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const Posts = styled.div`
+  width: 100%;
+`;
+
+const PostContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Divider = styled.div`
+  height: 0.5px;
+  background-color: rgba(219, 219, 219, 0.7);
+`;
+
+const SubmitButton = styled.div`
+  position: sticky;
+  bottom: 20px;
+  left: 50%;
+`;

--- a/src/app/home/write/post/page.tsx
+++ b/src/app/home/write/post/page.tsx
@@ -105,7 +105,7 @@ const WritePost = () => {
 
   useEffect(() => {
     console.log(inputs);
-  }, [inputs]);
+  }, []);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -140,6 +140,7 @@ const WritePost = () => {
             brand: inputs.brand,
             size: inputs.size,
             fit: inputs.fit,
+            clothesId: clothesId || null,
           }),
         ],
         { type: "application/json" }

--- a/src/app/home/write/post/page.tsx
+++ b/src/app/home/write/post/page.tsx
@@ -5,25 +5,34 @@ import Category from "@/components/common/Category";
 import Input from "@/components/common/Input";
 import { theme } from "@/styles/theme";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import axios from "axios";
 import { getToken } from "@/hooks/getToken";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/redux/store";
-import { clearCategory } from "@/redux/slices/categorySlice";
+import {
+  clearCategory,
+  setSelectedCategory,
+  setSelectedGender,
+  setSelectedStyle,
+} from "@/redux/slices/categorySlice";
 import { useRequireAuth } from "@/hooks/useAuth";
+import AuthAxios from "@/api/authAxios";
+import { convertURLtoFile } from "@/lib/convertURLtoFile";
 
 interface Price {
   days: number | null;
   price: number | null;
 }
-const Write = () => {
+const WritePost = () => {
   useRequireAuth();
   const router = useRouter();
   const dispatch = useDispatch();
+  const searchParams = useSearchParams();
+  const clothesId = searchParams.get("clothesId");
 
   const selectedGender = useSelector(
     (state: RootState) => state.category.selectedGender
@@ -60,6 +69,43 @@ const Write = () => {
     size: "",
     fit: "",
   });
+
+  /* 보유글 조회 */
+  useEffect(() => {
+    if (clothesId) {
+      AuthAxios.get(`/api/v1/clothes/${clothesId}`)
+        .then(async (response) => {
+          const data = response.data.result;
+          setInputs({
+            ...inputs,
+            title: data.name,
+            gender: data.gender,
+            category: data.category,
+            style: data.style,
+            brand: data.brand,
+            size: data.size,
+          });
+
+          const filePromises = data.imgUrls.map((image: string) =>
+            convertURLtoFile(image)
+          );
+          const files = await Promise.all(filePromises);
+          setImages(files);
+
+          dispatch(setSelectedGender(data.gender));
+          dispatch(setSelectedCategory(data.category));
+          dispatch(setSelectedStyle(data.style));
+          console.log(data);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    }
+  }, []);
+
+  useEffect(() => {
+    console.log(inputs);
+  }, [inputs]);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -322,7 +368,7 @@ const Write = () => {
   );
 };
 
-export default Write;
+export default WritePost;
 
 const Layout = styled.div`
   width: 100%;

--- a/src/components/home/Post.tsx
+++ b/src/components/home/Post.tsx
@@ -16,15 +16,19 @@ const Post: React.FC<PostList> = ({
   isReviewed = false, // 후기 작성 여부 (후기 보내기, 작성 완료)
   showReviewed = false, // 후기 버튼 유무
   onClickReview,
+  onClickChoice,
   createdAt,
   startDate,
   endDate,
   size = "nomal",
+  isSelected = false,
 }) => {
   const router = useRouter();
 
   const handleDetail = () => {
-    if (!isDeleted) {
+    if (onClickChoice && id !== undefined) {
+      onClickChoice(id);
+    } else if (!isDeleted) {
       router.push(`/home/${id}`);
     }
   };
@@ -39,7 +43,7 @@ const Post: React.FC<PostList> = ({
   };
 
   return (
-    <Container onClick={handleDetail} size={size}>
+    <Container onClick={handleDetail} size={size} isSelected={isSelected}>
       <Image
         src={`${imgUrl ? imgUrl : "/assets/images/noImage.svg"}`}
         width={size === "small" ? 60 : 76}
@@ -82,7 +86,7 @@ const Post: React.FC<PostList> = ({
 
 export default Post;
 
-const Container = styled.div<{ size: string }>`
+const Container = styled.div<{ size: string; isSelected: boolean }>`
   display: flex;
   width: 100%;
   height: 100px;
@@ -96,6 +100,11 @@ const Container = styled.div<{ size: string }>`
       border-bottom: 0.5px solid rgba(219, 219, 219, 0.7);
     `}
   cursor: pointer;
+  ${(props) =>
+    props.isSelected &&
+    css`
+      background-color: ${theme.colors.purple10};
+    `}
 `;
 
 const Box = styled.div`

--- a/src/data/homeData.ts
+++ b/src/data/homeData.ts
@@ -2,6 +2,7 @@ export type postType = "share" | "rental";
 
 export interface PostList {
     id?: number;
+    userSid?: string;
     postType?: postType;
     imgUrl?: string | null;
     nickname?: string;
@@ -11,59 +12,49 @@ export interface PostList {
     isReviewed?: boolean;
     showReviewed?: boolean;
     onClickReview?: () => void;
+    onClickChoice?: (id: number) => void;
     createdAt?: string;
     startDate?: string;
     endDate?: string;
     size?: "nomal" | "small";
+    isSelected?: boolean;
 }
 
 export const postList :PostList[] = [
     {
+        "id": 7,
+        "userSid": "cy8rNm1CNFA2dHhYdjlhYnhGWnpXQT09",
+        "imgUrl": "https://clotheser-s3-bucket.s3.ap-northeast-2.amazonaws.com/rentals/e03ad52f-8338-4895-b2bc-9d7ce07f4317_nasi_blouse_1.png",
+        "nickname": "카리나",
+        "title": "레이스 스트링 나시 블라우스",
+        "minPrice": 2000,
+        "createdAt": "25일 전"
+      },
+      {
         "id": 4,
+        "userSid": "QUtGMXJRcmRXeUJESVphSEFpSlBpUT09",
         "imgUrl": null,
         "nickname": "Clothes:er",
         "title": "오프숄더 리본 반팔 티",
         "minPrice": 4000,
-        "createdAt": "30분 전"
-    },
-    {
+        "createdAt": "1개월 전"
+      },
+      {
         "id": 3,
+        "userSid": "QUtGMXJRcmRXeUJESVphSEFpSlBpUT09",
         "imgUrl": null,
         "nickname": "Clothes:er",
         "title": "정장 세트",
         "minPrice": 5000,
-        "createdAt": "1시간 전"
-    },
-    {
+        "createdAt": "1개월 전"
+      },
+      {
         "id": 2,
+        "userSid": "VklpOFpuZFVvdGh5N2ZwU2RKVVM0UT09",
         "imgUrl": null,
         "nickname": "눈송이",
         "title": "청바지 멜빵 원피스",
         "minPrice": 4000,
-        "createdAt": "1일 전"
-    },
-    {
-        "id": 1,
-        "imgUrl": null,
-        "nickname": "Clothes:er",
-        "title": "오프숄더 리본 반팔 티",
-        "minPrice": 4000,
-        "createdAt": "30분 전"
-    },
-    {
-        "id": 5,
-        "imgUrl": null,
-        "nickname": "Clothes:er",
-        "title": "정장 세트",
-        "minPrice": 5000,
-        "createdAt": "1시간 전"
-    },
-    {
-        "id": 6,
-        "imgUrl": null,
-        "nickname": "눈송이",
-        "title": "청바지 멜빵 원피스",
-        "minPrice": 4000,
-        "createdAt": "1일 전"
-    },
+        "createdAt": "1개월 전"
+      },
 ];


### PR DESCRIPTION
## 연관 이슈

close #55

<br/>

## 🔍 작업 내용
보유글을 선택해 대여글 작성

- 보유글 목록을 통한 대여글 선택
- 해당 보유옷 조회 -> 데이터 불러오기 (이미지, 제목, 카테고리)
- 대여글 생성/조회/수정 clothesId 추가된 API 변동사항 반영

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/8ee367ca-a158-422c-89d4-be469108c52c


<br/>

## 📁 메모
보유글 "목록" 조회 API가 안 나온 상태로, 임의의 더미데이터를 넣은 상태

<br/>
