### PR TITLE
[Fix] 이미지 파일명 설정 등 오류 수정

### DIFF
--- a/src/app/home/write/post/page.tsx
+++ b/src/app/home/write/post/page.tsx
@@ -51,7 +51,7 @@ const WritePost = () => {
   const [inputs, setInputs] = useState<{
     title: string;
     description: string;
-    gender: string;
+    gender: string | null;
     category: string;
     style: string;
     prices: Price[];
@@ -61,7 +61,7 @@ const WritePost = () => {
   }>({
     title: "",
     description: "",
-    gender: selectedGender || "",
+    gender: selectedGender || null,
     category: selectedCategory || "",
     style: selectedStyle || "",
     prices: [
@@ -127,13 +127,13 @@ const WritePost = () => {
   };
 
   const handleNewPost = () => {
+    console.log("성별", selectedGender);
     const formattedPrices = inputs.prices.map((price) => ({
       days: price.days,
       price: price.price !== null ? Number(price.price) : null,
     }));
 
     const formData = new FormData();
-
     formData.append(
       "post",
       new Blob(
@@ -141,7 +141,7 @@ const WritePost = () => {
           JSON.stringify({
             title: inputs.title,
             description: inputs.description,
-            gender: selectedGender,
+            gender: selectedGender === "" ? null : selectedGender,
             category: selectedCategory,
             style: selectedStyle,
             prices: formattedPrices,

--- a/src/components/home/Post.tsx
+++ b/src/components/home/Post.tsx
@@ -81,7 +81,7 @@ const Post: React.FC<PostList> = ({
               {isDeleted
                 ? "삭제된 게시물입니다"
                 : postType === "choice"
-                ? `구매가 ${minPrice}원`
+                ? `구매가 ${minPrice ? `${minPrice}원` : "미기재"}`
                 : `${minPrice}원~`}
             </Price>
             <Days>

--- a/src/lib/convertURLtoFile.ts
+++ b/src/lib/convertURLtoFile.ts
@@ -4,7 +4,12 @@ export const convertURLtoFile = async (url: string) => {
 
   // url에서 파일 확장자와 파일명 추출 (기본값 제공)
   const ext = url.split(".").pop() || "jpg";
-  const filename = url.split("/").pop() || "filename.jpg";
+  let filename = url.split("/").pop() || "filename.jpg";
+
+  // 파일명에서 언더바가 존재하면 언더바 전까지 추출
+  if (filename.includes("_")) {
+    filename = filename.split("_")[0];
+  }
 
   // MIME 타입 설정
   const metadata = { type: `image/${ext}` };


### PR DESCRIPTION
## 연관 이슈

#82

<br/>

## 🔍 작업 내용

- 이미지 url → file 변환 시, 파일명 _ 앞 부분만 추출해서 전달
- 구매가 미기재 시 "구매가 미기재"로 설정
- 성별 기본 값 null로 지정 ("" 대신)

<br/>

