### PR TITLE
[Fix] 이미지 파일명 재수정, 거래 후기 페이지 및 가격 관련 수정

### DIFF
--- a/src/app/closet/[id]/page.tsx
+++ b/src/app/closet/[id]/page.tsx
@@ -18,6 +18,7 @@ import PrevArrow from "@/components/common/PrevArrow";
 import { useRequireAuth } from "@/hooks/useAuth";
 import MoreBox from "@/components/common/MoreBox";
 import Modal from "@/components/common/Modal";
+import { formatPrice } from "@/lib/formatPrice";
 
 interface PostInfo {
   id: number;
@@ -229,16 +230,20 @@ const Page = () => {
                     verticalAlign: "middle",
                   }}
                 >
-                  {postInfo?.shoppingUrl}
+                  {postInfo?.shoppingUrl ? postInfo.shoppingUrl : "없음"}
                 </ShoppingUrl>
               </Row>
               <Row>
                 <Label>구매처</Label>
-                <div>{postInfo?.brand}</div>
+                <div>{postInfo?.brand ? postInfo.brand : "없음"}</div>
               </Row>
               <Row>
                 <Label>구매 가격</Label>
-                <div>{postInfo?.price}원</div>
+                <div>
+                  {postInfo?.price
+                    ? `${formatPrice(postInfo?.price || 0)}원`
+                    : "없음"}
+                </div>
               </Row>
             </Info>
             <div>옷 후기</div>

--- a/src/app/mycloset/[clothesId]/page.tsx
+++ b/src/app/mycloset/[clothesId]/page.tsx
@@ -18,6 +18,7 @@ import PrevArrow from "@/components/common/PrevArrow";
 import { useRequireAuth } from "@/hooks/useAuth";
 import MoreBox from "@/components/common/MoreBox";
 import Modal from "@/components/common/Modal";
+import { formatPrice } from "@/lib/formatPrice";
 
 interface PostInfo {
   id: number;
@@ -209,16 +210,20 @@ const Page = () => {
                     verticalAlign: "middle",
                   }}
                 >
-                  {postInfo?.shoppingUrl}
+                  {postInfo?.shoppingUrl ? postInfo.shoppingUrl : "없음"}
                 </ShoppingUrl>
               </Row>
               <Row>
                 <Label>구매처</Label>
-                <div>{postInfo?.brand}</div>
+                <div>{postInfo?.brand ? postInfo.brand : "없음"}</div>
               </Row>
               <Row>
                 <Label>구매 가격</Label>
-                <div>{postInfo?.price}원</div>
+                <div>
+                  {postInfo?.price
+                    ? `${formatPrice(postInfo?.price || 0)}원`
+                    : "없음"}
+                </div>
               </Row>
             </Info>
             <div>옷 후기</div>

--- a/src/components/home/Bottom.tsx
+++ b/src/components/home/Bottom.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { chatListType } from "@/type/chat";
 import { showToast } from "@/hooks/showToast";
+import { formatPrice } from "@/lib/formatPrice";
 
 type bottomType = "share" | "closet";
 
@@ -114,7 +115,7 @@ const Bottom: React.FC<BottomProps> = ({
       {bottomType === "share" && (
         <div>
           <Price>
-            {sortedByPrice ? sortedByPrice[0]?.price : "N/A"}원~
+            {sortedByPrice ? formatPrice(sortedByPrice[0]?.price) : "N/A"}원~
             <Days>{sortedByPrice && sortedByPrice[0]?.days}일</Days>
           </Price>
           <MorePrice onClick={handleShowPrice}>가격표 보기</MorePrice>
@@ -126,7 +127,9 @@ const Bottom: React.FC<BottomProps> = ({
                   {sortedByDays?.map((data, index) => (
                     <Set key={index}>
                       <DaysPopup>{data.days}일 :</DaysPopup>
-                      <PricesPopup>{data.price}원</PricesPopup>
+                      <PricesPopup>
+                        {formatPrice(data.price || 0)}원
+                      </PricesPopup>
                     </Set>
                   ))}
                 </Table>

--- a/src/components/home/Bottom.tsx
+++ b/src/components/home/Bottom.tsx
@@ -231,7 +231,7 @@ const PricePopup = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 200;
+  z-index: 1000;
 `;
 
 const Table = styled.div`
@@ -265,7 +265,7 @@ const Overlay = styled.div`
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  z-index: 100;
+  z-index: 900;
 `;
 
 const Span = styled.span`

--- a/src/components/home/Post.tsx
+++ b/src/components/home/Post.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import styled, { css } from "styled-components";
+import { formatPrice } from "@/lib/formatPrice";
 
 const Post: React.FC<PostList> = ({
   id,
@@ -81,8 +82,10 @@ const Post: React.FC<PostList> = ({
               {isDeleted
                 ? "삭제된 게시물입니다"
                 : postType === "choice"
-                ? `구매가 ${minPrice ? `${minPrice}원` : "미기재"}`
-                : `${minPrice}원~`}
+                ? `구매가 ${
+                    minPrice ? `${formatPrice(minPrice || 0)}원` : "미기재"
+                  }`
+                : `${formatPrice(minPrice || 0)}원~`}
             </Price>
             <Days>
               {isDeleted ? "" : postType !== "choice" && `${minDays}day`}

--- a/src/components/review/KeywordBox.tsx
+++ b/src/components/review/KeywordBox.tsx
@@ -18,7 +18,7 @@ const Box = styled.div`
   height: 29px;
   padding: 5px 14px;
   border-radius: 15px;
-  background: ${theme.colors.gray100};
+  background: ${theme.colors.purple100};
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/review/ReviewPage.tsx
+++ b/src/components/review/ReviewPage.tsx
@@ -43,29 +43,43 @@ const ReviewPage: React.FC<ReviewProps> = ({
         />
         <Label>{nickname} 님</Label>
       </Profile>
-      <div>
-        <Label>받은 키워드 후기</Label>
-        <Keywords>
-          {keywordReviews.map((item, index) => (
-            <KeywordBox key={index} keyword={item.keyword} count={item.count} />
-          ))}
-        </Keywords>
-      </div>
-      <div>
-        <Label>받은 텍스트 후기</Label>
-        <Texts>
-          {textReviews.map((item, index) => (
-            <TextBox
-              key={index}
-              nickname={item.nickname}
-              profileUrl={item.profileUrl}
-              userSid={item.userSid}
-              content={item.content}
-              createdAt={item.createdAt}
-            />
-          ))}
-        </Texts>
-      </div>
+      <Left>
+        <div>
+          <Label>받은 키워드 후기</Label>
+          <Keywords>
+            {keywordReviews ? (
+              keywordReviews.map((item, index) => (
+                <KeywordBox
+                  key={index}
+                  keyword={item.keyword}
+                  count={item.count}
+                />
+              ))
+            ) : (
+              <NoData>아직 받은 키워드 후기가 없네요!</NoData>
+            )}
+          </Keywords>
+        </div>
+        <div>
+          <Label>받은 텍스트 후기</Label>
+          <Texts>
+            {textReviews ? (
+              textReviews.map((item, index) => (
+                <TextBox
+                  key={index}
+                  nickname={item.nickname}
+                  profileUrl={item.profileUrl}
+                  userSid={item.userSid}
+                  content={item.content}
+                  createdAt={item.createdAt}
+                />
+              ))
+            ) : (
+              <NoData>아직 받은 텍스트 후기가 없네요!</NoData>
+            )}
+          </Texts>
+        </div>
+      </Left>
     </Container>
   );
 };
@@ -74,6 +88,7 @@ export default ReviewPage;
 
 const Container = styled.div`
   display: flex;
+  width: 100%;
   height: 100%;
   flex-direction: column;
   align-items: center;
@@ -81,11 +96,21 @@ const Container = styled.div`
 `;
 
 const Profile = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
 `;
+
+const Left = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 50px;
+`;
+
 const Label = styled.div`
   color: ${theme.colors.b500};
   ${(props) => props.theme.fonts.b2_bold};
@@ -104,4 +129,20 @@ const Texts = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
+`;
+
+const NoData = styled.div`
+  width: 100%;
+  height: auto;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: ${theme.colors.gray800};
+  ${(props) => props.theme.fonts.b2_regular}
+
+  @media screen and (max-width: 400px) {
+    ${(props) => props.theme.fonts.b3_regular}
+  }
 `;

--- a/src/lib/convertURLtoFile.ts
+++ b/src/lib/convertURLtoFile.ts
@@ -6,9 +6,9 @@ export const convertURLtoFile = async (url: string) => {
   const ext = url.split(".").pop() || "jpg";
   let filename = url.split("/").pop() || "filename.jpg";
 
-  // 파일명에서 언더바가 존재하면 언더바 전까지 추출
+  // 파일명에서 언더바가 존재하면 언더바 뒷부분을 추출
   if (filename.includes("_")) {
-    filename = filename.split("_")[0];
+    filename = filename.split("_")[1];
   }
 
   // MIME 타입 설정


### PR DESCRIPTION
## 연관 이슈

#82

<br/>

## 🔍 작업 내용
- 파일명 언더바 뒷부분을 추출
- 가격표 포맷팅, 옷장 구경 및 나의 옷장 정보 미기재 시 화면 처리
- 거래 후기 페이지 정렬 및 데이터 없을 경우 화면 처리

<br/>

## 🖥 구현 결과 (선택)

![image](https://github.com/user-attachments/assets/0f9c32e2-5430-4310-a5e8-15287e41277f)

![image](https://github.com/user-attachments/assets/742fbb77-83a9-4c66-b0ae-23e5b52495bd)

![image](https://github.com/user-attachments/assets/00465460-0ffd-44e8-a310-3000bd3b41ab)

<br/>

