### PR TITLE
[Feat] 보유글 관련 찜하기 기능, 토큰 재발급 400 오류 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,7 @@ import withPWA from "next-pwa";
 import typescript from "next-plugin-graphql";
 
 const nextConfig = {
+  reactStrictMode: false,
   compiler: {
     styledComponents: true,
   },

--- a/src/api/authAxios.ts
+++ b/src/api/authAxios.ts
@@ -23,9 +23,9 @@ AuthAxios.interceptors.response.use(
     
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-      const refreshToken = localStorage.getItem("refreshToken");
-
-      if (refreshToken) {
+      const refreshToken = localStorage.getItem("refreshToken")?? "";
+      console.log("재발급할 때 보내지는 refreshToken", refreshToken);
+      if (refreshToken.length>0) {
         try {
           const response = await axios.post(
             `${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/users/reissue-token`,
@@ -41,7 +41,13 @@ AuthAxios.interceptors.response.use(
             console.log("토큰 재발급 완료", response.data);
             return AuthAxios(originalRequest);
           }
-        } catch (tokenRefreshError:any) {
+        } catch (tokenRefreshError: any) {
+            if (tokenRefreshError.response?.status === 400) {
+              console.error(
+                "400 에러: 유효하지 않은 리프레시 토큰입니다.",
+                tokenRefreshError.response.data
+              );
+            }
           if (tokenRefreshError.response?.status === 401) {
             console.error("토큰이 만료되었습니다. 재로그인을 해주세요.");
           }

--- a/src/api/like.ts
+++ b/src/api/like.ts
@@ -32,3 +32,38 @@ export const getRentalLikes = async() => {
     throw error;
    }
 }
+
+export const postClothesLike = async (clothesId: number) => {
+  try {
+    const response = await AuthAxios.post(`/api/v1/clothes/${clothesId}/like`);
+    console.log("보유글 찜 생성 성공");
+    return response.data;
+  } catch (error) {
+    console.log("대여글 찜 생성 실패");
+    throw error;
+  }
+};
+
+export const deleteClothesLike = async (clothesId: number) => {
+  try {
+    const response = await AuthAxios.delete(
+      `/api/v1/clothes/${clothesId}/like`
+    );
+    console.log("보유글 찜 삭제 성공");
+    return response.data;
+  } catch (error) {
+    console.log("대여글 찜 삭제 실패");
+    throw error;
+  }
+};
+
+export const getClothesLikes = async () => {
+  try {
+    const response = await AuthAxios.get(`/api/v1/closet/like-clothes`);
+    console.log("나의 보유글 찜 목록 조회 성공");
+    return response.data;
+  } catch (error) {
+    console.log("나의 보유글 찜 목록 조회 실패");
+    throw error;
+  }
+};

--- a/src/api/like.ts
+++ b/src/api/like.ts
@@ -39,7 +39,7 @@ export const postClothesLike = async (clothesId: number) => {
     console.log("보유글 찜 생성 성공");
     return response.data;
   } catch (error) {
-    console.log("대여글 찜 생성 실패");
+    console.log("보유글 찜 생성 실패");
     throw error;
   }
 };
@@ -52,7 +52,7 @@ export const deleteClothesLike = async (clothesId: number) => {
     console.log("보유글 찜 삭제 성공");
     return response.data;
   } catch (error) {
-    console.log("대여글 찜 삭제 실패");
+    console.log("보유글 찜 삭제 실패");
     throw error;
   }
 };

--- a/src/app/closet/[id]/page.tsx
+++ b/src/app/closet/[id]/page.tsx
@@ -49,6 +49,8 @@ interface PostInfo {
   size: string;
   shoppingUrl: string;
   isPublic: boolean;
+  isLiked: boolean;
+  likeCount: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -300,6 +302,8 @@ const Page = () => {
               userSid={postInfo.userSid}
               isWriter={postInfo.isWriter}
               isWithdrawn={postInfo.isWithdrawn}
+              isLiked={postInfo.isLiked}
+              likeCount={postInfo.likeCount}
             />
           )}
           {/* 삭제하기 모달 */}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -106,7 +106,7 @@ const Home = () => {
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true); // 로딩 시작
-      console.log("토큰", getToken());
+      console.log("accessToken", getToken());
       try {
         const response = await AuthAxios.get(`/api/v1/users/address`);
         const latitude = response.data.result.latitude;
@@ -220,7 +220,9 @@ const Home = () => {
                 alt="pin"
               />
             )}
-            {loading ? "Loading..." : location || "위치를 설정해 주세요"}
+            {loading
+              ? "주소를 찾고 있어요..."
+              : location || "위치를 설정해 주세요"}
           </Location>
           <Content>
             <SearchBox

--- a/src/app/mycloset/page.tsx
+++ b/src/app/mycloset/page.tsx
@@ -76,7 +76,6 @@ const MyCloset = () => {
         setStyle(data.styles);
         console.log(data);
         console.log(response.data.message);
-        console.log(getLevelText(profileInfo?.level || 0));
       })
       .catch((error) => {
         console.log(error);

--- a/src/components/common/SquarePost.tsx
+++ b/src/components/common/SquarePost.tsx
@@ -92,6 +92,8 @@ export default SquarePost;
 
 const Container = styled.div`
   width: 100%;
+  max-width: 210px;
+  min-width: 140px;
   height: 184px;
 `;
 
@@ -117,8 +119,6 @@ const HeartImage = styled(Image)`
 
 const Title = styled.div`
   width: 100%;
-  max-width: 210px;
-  min-width: 140px;
   margin-top: 10px;
   margin-bottom: 3px;
   color: #242029;

--- a/src/components/common/SquarePost.tsx
+++ b/src/components/common/SquarePost.tsx
@@ -1,3 +1,4 @@
+import { deleteClothesLike, postClothesLike } from "@/api/like";
 import { theme } from "@/styles/theme";
 import { ClosetPostList } from "@/type/post";
 import Image from "next/image";
@@ -7,8 +8,18 @@ import styled, { css } from "styled-components";
 
 const SquarePost: React.FC<ClosetPostList> = (props) => {
   const router = useRouter();
-  const { id, userSid, nickname, imgUrl, name, brand, createdAt } = props;
-  const [heart, setHeart] = useState<boolean>(false);
+  const {
+    id,
+    userSid,
+    nickname,
+    imgUrl,
+    name,
+    brand,
+    createdAt,
+    isLikeList = false,
+    isLiked = false,
+  } = props;
+  const [heart, setHeart] = useState<boolean>(isLiked);
 
   const currentPath =
     typeof window !== "undefined" ? window.location.pathname : "";
@@ -27,6 +38,20 @@ const SquarePost: React.FC<ClosetPostList> = (props) => {
     router.push(`/user/${id}`);
   };
 
+  const handlePickHeart = async (event: React.MouseEvent<HTMLImageElement>) => {
+    event.stopPropagation();
+    // 찜하기 API
+    if (id) {
+      if (heart) {
+        await deleteClothesLike(id);
+        setHeart(false);
+      } else {
+        await postClothesLike(id);
+        setHeart(true);
+      }
+    }
+  };
+
   return (
     <Container onClick={() => handleMorePost(id)}>
       <ImageBox>
@@ -35,15 +60,15 @@ const SquarePost: React.FC<ClosetPostList> = (props) => {
           fill
           alt="image"
         />
-        {/* <HeartImage
-          src={`/assets/icons/ic_heart${heart ? "_fill" : ""}.svg`}
-          width={20}
-          height={20}
-          alt="storage"
-          onClick={() => {
-            setHeart(!heart);
-          }}
-        /> */}
+        {isLikeList && (
+          <HeartImage
+            src={`/assets/icons/ic_heart${heart ? "_fill" : ""}.svg`}
+            width={20}
+            height={20}
+            alt="찜"
+            onClick={handlePickHeart}
+          />
+        )}
       </ImageBox>
       <Title>{name}</Title>
       <Sub>

--- a/src/components/common/SquarePost.tsx
+++ b/src/components/common/SquarePost.tsx
@@ -25,7 +25,7 @@ const SquarePost: React.FC<ClosetPostList> = (props) => {
     typeof window !== "undefined" ? window.location.pathname : "";
 
   const handleMorePost = (id: number) => {
-    if (currentPath.startsWith("/user")) {
+    if (isLikeList || currentPath.startsWith("/user")) {
       router.push(`/closet/${id}`);
     } else if (currentPath.startsWith("/mycloset")) {
       router.push(`/mycloset/${id}`);

--- a/src/components/home/Bottom.tsx
+++ b/src/components/home/Bottom.tsx
@@ -198,7 +198,7 @@ const Bottom: React.FC<BottomProps> = ({
             </div>
           ) : (
             <div>
-              <Span>궁금한 정보</Span>를 <Span>문의</Span>해보세요!
+              <Span>궁금한 점</Span>을 <Span>물어</Span>보세요!
             </div>
           ))}
       </LeftDiv>

--- a/src/components/home/Bottom.tsx
+++ b/src/components/home/Bottom.tsx
@@ -7,7 +7,12 @@ import { chatListType } from "@/type/chat";
 import { showToast } from "@/hooks/showToast";
 import { formatPrice } from "@/lib/formatPrice";
 import Image from "next/image";
-import { deleteRentalLike, postRentalLike } from "@/api/like";
+import {
+  deleteClothesLike,
+  deleteRentalLike,
+  postClothesLike,
+  postRentalLike,
+} from "@/api/like";
 
 type bottomType = "share" | "closet";
 
@@ -59,11 +64,15 @@ const Bottom: React.FC<BottomProps> = ({
     // 찜하기 API
     if (id) {
       if (heart) {
-        await deleteRentalLike(id);
+        bottomType === "share"
+          ? await deleteRentalLike(id)
+          : await deleteClothesLike(id);
         setHeart(false);
         setHeartCount(heartCount - 1);
       } else {
-        await postRentalLike(id);
+        bottomType === "share"
+          ? await postRentalLike(id)
+          : await postClothesLike(id);
         setHeart(true);
         setHeartCount(heartCount + 1);
       }

--- a/src/components/myCloset/StorageClosetContent.tsx
+++ b/src/components/myCloset/StorageClosetContent.tsx
@@ -1,10 +1,80 @@
-const StorageClosetContent = () => {
+import { getClothesLikes } from "@/api/like";
+import { theme } from "@/styles/theme";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import SquarePost from "../common/SquarePost";
+import { ClosetLikeList } from "@/type/like";
+
+interface MyClosetContentProps {
+  userSid?: string;
+}
+
+const StorageClosetContent: React.FC<MyClosetContentProps> = ({ userSid }) => {
+  const [postList, setPostList] = useState<ClosetLikeList[]>();
+
+  useEffect(() => {
+    const fetchRentalLikes = async () => {
+      try {
+        const data = await getClothesLikes();
+        setPostList(data.result);
+        console.log(data);
+      } catch (error) {}
+    };
+
+    fetchRentalLikes();
+  }, []);
+
   return (
-    <div>
-      <h2>옷장구경 찜 목록</h2>
-      {/* 예시 콘텐츠 */}
-    </div>
+    <>
+      {postList && postList?.length > 0 ? (
+        <GridContainer>
+          {postList.map((data) => (
+            <SquarePost
+              key={data.clothesListResponse.id}
+              id={data.clothesListResponse.id}
+              userSid={data.clothesListResponse.userSid}
+              nickname={data.clothesListResponse.nickname}
+              name={data.clothesListResponse.name}
+              imgUrl={data.clothesListResponse.imgUrl}
+              createdAt={data.clothesListResponse.createdAt}
+              isLikeList={true}
+              isLiked={data.isLiked}
+            />
+          ))}
+        </GridContainer>
+      ) : (
+        <NoData>
+          <>지금 바로 찜하기를 시작해보세요!</>
+        </NoData>
+      )}
+    </>
   );
 };
 
 export default StorageClosetContent;
+
+const GridContainer = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding: 10px 0;
+  justify-content: center;
+  row-gap: 15px;
+  column-gap: 22px;
+`;
+
+const NoData = styled.div`
+  width: 100%;
+  height: 100%;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: ${theme.colors.gray800};
+  ${(props) => props.theme.fonts.b2_regular}
+
+  @media screen and (max-width: 400px) {
+    ${(props) => props.theme.fonts.b3_regular}
+  }
+`;

--- a/src/components/myCloset/StorageRentalContent.tsx
+++ b/src/components/myCloset/StorageRentalContent.tsx
@@ -3,16 +3,15 @@ import Post from "../home/Post";
 import styled from "styled-components";
 import { theme } from "@/styles/theme";
 import { getRentalLikes } from "@/api/like";
-import { LikeList } from "@/type/like";
+import { RentalLikeList } from "@/type/like";
 
 interface MyShareContentProps {
   userSid?: string;
 }
 
 const StorageRentalContent: React.FC<MyShareContentProps> = ({ userSid }) => {
-  const [postList, setPostList] = useState<LikeList[]>();
+  const [postList, setPostList] = useState<RentalLikeList[]>();
 
-  /* 보유 > 공유 등록 목록 조회 */
   useEffect(() => {
     const fetchRentalLikes = async () => {
       try {

--- a/src/type/like.ts
+++ b/src/type/like.ts
@@ -1,4 +1,4 @@
-export interface LikeList {
+export interface RentalLikeList {
   rentalListResponse: {
     id: number;
     imgUrl: string;
@@ -7,6 +7,18 @@ export interface LikeList {
     minDays: number;
     nickname: string;
     brand: string;
+    createdAt: string;
+  };
+  isLiked: boolean;
+}
+
+export interface ClosetLikeList {
+  clothesListResponse: {
+    id: number;
+    userSid: string;
+    nickname: string;
+    imgUrl: string;
+    name: string;
     createdAt: string;
   };
   isLiked: boolean;

--- a/src/type/post.ts
+++ b/src/type/post.ts
@@ -29,11 +29,13 @@ export interface PostList {
 }
 
 export interface ClosetPostList {
-    id: number;
-    userSid: string;
-    nickname?: string;
-    imgUrl: string;
-    name?: string;
-    brand?: string;
-    createdAt: string;
-  }
+  id: number;
+  userSid: string;
+  nickname?: string;
+  imgUrl: string;
+  name?: string;
+  brand?: string;
+  createdAt: string;
+  isLikeList?: boolean;
+  isLiked?: boolean;
+}


### PR DESCRIPTION
## 연관 이슈

close #100

<br/>

## 🔍 작업 내용
- 보유글 찜 생성, 삭제
- 보유글 찜 목록 조회
- SquarePost 컴포넌트 말줄임표 추가에 따른 컴포넌트 크기 오류 수정
- 토큰 재발급 400 오류 수정 (재발급 조건문 refreshToken.length>0 변경)

<br/>

## 🖥 구현 결과 (선택)


https://github.com/user-attachments/assets/36f3f983-3c3e-4a6c-aaa2-c4838b65438b



<br/>

