### PR TITLE
[Fix] 푸시 알림 연결 시 채팅 오류 해결

### DIFF
--- a/src/api/deviceToken.ts
+++ b/src/api/deviceToken.ts
@@ -6,7 +6,7 @@ export async function getDeviceToken() {
    const token = await getToken(messaging, {
     vapidKey: process.env.NEXT_PUBLIC_VAPID_KEY,
   })
-  alert("Device Token: " + token);
+  console.log("디바이스 토큰 가져오기 성공");
   console.log("Device Token: ", token);
   return token;
 }


### PR DESCRIPTION
## 연관 이슈

close #115

<br/>

## 🔍 작업 내용
푸시 알림이 동작할 경우 보낸 메세지가 바로 업데이트 되지 않는 문제 해결
→ 채팅목록 조회에서 매번 받아오지 않고, 소켓으로 전달받은 메세지로 상태관리 진행
(채팅목록 조회 응답값이 업데이트 되는 데에 딜레이 발생 문제)
<br/>