### PR TITLE
[Fix] 컴포넌트로 분리하여 disable server-side rendering

### DIFF
--- a/src/api/deviceToken.ts
+++ b/src/api/deviceToken.ts
@@ -3,6 +3,8 @@ import { getToken } from "firebase/messaging";
 import { messaging } from "../core/notification/settingFCM";
 
 export async function getDeviceToken() {
+  if (typeof window === "undefined") return null;
+
    const token = await getToken(messaging, {
     vapidKey: process.env.NEXT_PUBLIC_VAPID_KEY,
   })
@@ -12,6 +14,8 @@ export async function getDeviceToken() {
 }
 
 export async function patchDeviceToken(token: string) {
+  if (typeof window === "undefined") return null;
+
   try {
     const response = await AuthAxios.patch(`/api/v1/notifications/token`, {
       deviceToken: token,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,10 +3,6 @@
 import Axios from "@/api/axios";
 import { setUser } from "@/redux/slices/userSlice";
 import {
-  handleAllowNotification,
-  registerServiceWorker,
-} from "@/util/notification";
-import {
   setIsAutoLogin,
   setIsFirstLogin,
   setIsSuspended,
@@ -15,11 +11,13 @@ import {
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
+import LoginPage from "@/components/login/LoinPage";
 import dynamic from "next/dynamic";
 
-const LoginPage = dynamic(() => import("@/components/login/LoinPage"), {
-  ssr: false,
-});
+const DeviceTokenComponent = dynamic(
+  () => import("@/components/login/DeviceTokenComponent"),
+  { ssr: false }
+);
 
 export default function Login() {
   const router = useRouter();
@@ -29,97 +27,79 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [save, setSave] = useState(false);
   const [error, setError] = useState<string>("");
-  const [notificationPermission, setNotificationPermission] = useState<
-    "granted" | "denied" | "default" | null
-  >(null);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const handleSave = () => {
     setSave(!save);
   };
 
-  /* 로그인 성공 후 알림 설정 및 디바이스 토큰 발급 */
-  useEffect(() => {
-    const initNotification = async () => {
-      const permission = await handleAllowNotification(); // 알림 권한 요청
-      setNotificationPermission(permission || null);
-      if (permission === "granted") {
-        registerServiceWorker(); // 권한이 허용되면 Service Worker 등록
-      }
-    };
-
-    if (
-      notificationPermission === "default" ||
-      notificationPermission === null
-    ) {
-      initNotification();
-    }
-  }, [notificationPermission]);
-
-  const handleLogin = () => {
-    Axios.post("/api/v1/users/login", {
-      email: email,
-      password: password,
-    })
-      .then((response) => {
-        console.log("로그인 성공", response.data);
-        const userData = {
-          name: "",
-          nickname: "",
-          email: response.data.result.email,
-          password: "",
-          phone: "",
-          birth: "",
-          token: response.data.result.token.accessToken,
-          isFirstLogin: response.data.result.isFirstLogin,
-          isSuspended: response.data.result.isSuspended,
-        };
-        dispatch(setUser(userData));
-        setTokens(
-          response.data.result.token.accessToken,
-          response.data.result.token.refreshToken,
-          String(save)
-        );
-        setIsAutoLogin(String(save));
-        setIsFirstLogin(userData.isFirstLogin);
-        setIsSuspended(userData.isSuspended);
-
-        setNotificationPermission("default");
-
-        if (userData.isFirstLogin) {
-          router.push("/first/step1");
-        } else {
-          router.push("/home");
-        }
-      })
-      .catch((error) => {
-        console.log("로그인 실패", error);
-        if (error.response) {
-          if (
-            error.response.data.code === 2130 ||
-            error.response.data.code === 3101
-          ) {
-            console.log(error.response.data.code);
-            setError("이메일 또는 비밀번호가 잘못되었습니다.");
-          } else {
-            setError(error.response.data.message);
-          }
-        } else {
-          setError("이메일과 비밀번호를 확인해주세요.");
-        }
+  useEffect(() => {}, [isLoggedIn]);
+  const handleLogin = async () => {
+    try {
+      const response = await Axios.post("/api/v1/users/login", {
+        email: email,
+        password: password,
       });
+
+      setIsLoggedIn(true);
+      console.log("로그인 성공", response.data);
+      const userData = {
+        name: "",
+        nickname: "",
+        email: response.data.result.email,
+        password: "",
+        phone: "",
+        birth: "",
+        token: response.data.result.token.accessToken,
+        isFirstLogin: response.data.result.isFirstLogin,
+        isSuspended: response.data.result.isSuspended,
+      };
+      dispatch(setUser(userData));
+      setTokens(
+        response.data.result.token.accessToken,
+        response.data.result.token.refreshToken,
+        String(save)
+      );
+      setIsAutoLogin(String(save));
+      setIsFirstLogin(userData.isFirstLogin);
+      setIsSuspended(userData.isSuspended);
+
+      if (userData.isFirstLogin) {
+        router.push("/first/step1");
+      } else {
+        router.push("/home");
+      }
+    } catch (error: any) {
+      console.log("로그인 실패", error);
+      if (error.response) {
+        if (
+          error.response.data.code === 2130 ||
+          error.response.data.code === 3101
+        ) {
+          console.log(error.response.data.code);
+          setError("이메일 또는 비밀번호가 잘못되었습니다.");
+        } else {
+          setError(error.response.data.message);
+        }
+      } else {
+        setError("이메일과 비밀번호를 확인해주세요.");
+      }
+    }
   };
 
   return (
-    <LoginPage
-      email={email}
-      setEmail={setEmail}
-      password={password}
-      setPassword={setPassword}
-      handleSave={handleSave}
-      save={save}
-      error={error}
-      handleLogin={handleLogin}
-      notificationPermission={notificationPermission}
-    />
+    <>
+      <LoginPage
+        email={email}
+        setEmail={setEmail}
+        password={password}
+        setPassword={setPassword}
+        handleSave={handleSave}
+        save={save}
+        error={error}
+        handleLogin={handleLogin}
+      />
+      {isLoggedIn && <DeviceTokenComponent />}
+    </>
   );
 }

--- a/src/components/login/DeviceTokenComponent.tsx
+++ b/src/components/login/DeviceTokenComponent.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { registerServiceWorker } from "@/util/notification";
+import { getDeviceToken, patchDeviceToken } from "@/api/deviceToken";
+
+const DeviceTokenComponent = () => {
+  useEffect(() => {
+    const requestDeviceToken = async () => {
+      const permission = await Notification.requestPermission();
+      if (permission === "granted") {
+        console.log("알림 권한이 허용되었습니다.");
+        await registerServiceWorker();
+
+        const token = await getDeviceToken();
+        if (token) {
+          await patchDeviceToken(token);
+          console.log("Device token 발급 및 전송 완료");
+        } else {
+          console.error("Failed to get device token");
+        }
+      } else if (permission === "denied") {
+        console.log("알림 권한이 거부되었습니다.");
+      } else {
+        console.log("사용자가 알림 권한을 결정하지 않았습니다.");
+      }
+    };
+
+    requestDeviceToken();
+  }, []);
+
+  return null;
+};
+
+export default DeviceTokenComponent;

--- a/src/components/login/LoinPage.tsx
+++ b/src/components/login/LoinPage.tsx
@@ -15,7 +15,6 @@ interface LoginPageProps {
   save: boolean;
   error: string;
   handleLogin: () => void;
-  notificationPermission: "granted" | "denied" | "default" | null;
 }
 
 export default function LoginPage({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,7 @@ export default function middleware(request: NextRequest) {
   if (
     request.nextUrl.pathname.startsWith("/images") ||
     request.nextUrl.pathname.endsWith(".svg") ||
+    request.nextUrl.pathname.endsWith(".png") ||
     request.nextUrl.pathname === "/manifest.json"
   ) {
     return NextResponse.next();

--- a/src/util/notification.ts
+++ b/src/util/notification.ts
@@ -1,5 +1,3 @@
-import { getDeviceToken, patchDeviceToken } from "@/api/deviceToken";
-
 export async function registerServiceWorker() {
   if (typeof window !== "undefined" && "serviceWorker" in navigator) {
     try {
@@ -9,24 +7,4 @@ export async function registerServiceWorker() {
       console.log("Service Worker 등록 실패:", error);
     }
   }
-}
-
-export async function handleAllowNotification() {
-  if (typeof window === "undefined") return;
-  
-    const permission = await Notification.requestPermission();
-    if (permission === "granted") {
-      console.log("알림 권한이 허용되었습니다.");
-      const token = await getDeviceToken();
-      if (token) {
-        await patchDeviceToken(token);
-      } else {
-        console.error("Failed to get device token");
-      }
-    } else if (permission === "denied") {
-      console.log("알림 권한이 거부되었습니다.");
-    } else {
-      console.log("사용자가 알림 권한을 결정하지 않았습니다.");
-  }
-    return permission;
 }


### PR DESCRIPTION
## 연관 이슈

close #118

<br/>

## 🔍 작업 내용

컴포넌트로 분리하여 disable server-side rendering

<br/>

## 📁 메모
아래와 같은 형태로 [Disable server-side rendering for components using browser APIs](https://nextjs.org/docs/messages/prerender-error) 를 사용하여 DeviceTokenComponent를 분리하고, 이를 로그인 여부를 useState로 관리하는 변수에 따라 렌더링하여 처리한다.
```
import dynamic from 'next/dynamic'
 
const DynamicComponentWithNoSSR = dynamic(
  () => import('../components/BrowserOnlyComponent'),
  { ssr: false }
)
 
export default function Page() {
  return (
    <div>
      <h1>My page</h1>
      <DynamicComponentWithNoSSR />
    </div>
  )
}
```
<br/>\
